### PR TITLE
Move petgraph dep to be upstream

### DIFF
--- a/pagegraph/Cargo.toml
+++ b/pagegraph/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../README.md"
 
 [dependencies]
 xml-rs = "^ 0.8"
-petgraph = {git = "https://github.com/antonok-edm/petgraph", branch = "edges-undirected", version = "^ 0.5", default_features = false, features = ["graphmap"]}
+petgraph = "^0.6.3"
 adblock = "^ 0.2"
 url = "^ 2.1"
 addr = "^ 0.2"


### PR DESCRIPTION
Now both `cargo build` and `cargo publish --dry-run` work. If we want to publish this crate we need to get rid of the unpublished dependency.

I tested a few examples locally through the sugarcoat-pipeline tests. Unfortunately not comprehensive.