### PR TITLE
Update adblock-rust dependency

### DIFF
--- a/pagegraph/Cargo.toml
+++ b/pagegraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pagegraph"
-version = "0.1.1"
+version = "0.1.2"
 description = "Rust library for analyzing PageGraph files"
 license-file = "../LICENSE"
 authors = ["Anton Lazarev <alazarev@brave.com>"]
@@ -10,7 +10,7 @@ readme = "../README.md"
 [dependencies]
 xml-rs = "^ 0.8"
 petgraph = "^0.6.3"
-adblock = "^ 0.2"
+adblock = "^ 0.7"
 url = "^ 2.1"
 addr = "^ 0.15"
 serde = { version = "^ 1.0", features = ["derive"], optional = true }

--- a/pagegraph/src/graph_algos.rs
+++ b/pagegraph/src/graph_algos.rs
@@ -458,7 +458,7 @@ impl PageGraph {
         let source_url = url::Url::parse(&source_url).expect("Could not parse source URL");
         let source_hostname = source_url.host_str().expect(&format!("Source URL has no host, {:?}", source_url));
         let source_domain = get_domain(source_hostname);
-        let blocker = Engine::from_rules_debug(&patterns);
+        let blocker = Engine::from_rules_debug(&patterns, Default::default());
 
         for (id, node) in self.nodes.iter() {
             match &node.node_type {


### PR DESCRIPTION
Older version of adblock-rust has an indirect dependency on an older version of psl